### PR TITLE
Create \consistEE wrapper

### DIFF
--- a/edition-engraver.ily
+++ b/edition-engraver.ily
@@ -35,3 +35,24 @@
 % activate edition-engraver module
 #(use-modules (edition-engraver engine))
 
+% Install the edition-engraver in the contexts
+% specified by the argument list
+consistEE =
+#(define-scheme-function (contexts)(symbol-list?)
+   #{
+     \layout {
+       #(map
+         (lambda (ctx)
+           (if (and (defined? ctx)
+                    (ly:context-def? (eval ctx (current-module))))
+               #{
+                 \context {
+                   #(eval ctx (current-module))
+                   \consists \edition-engraver
+                 }
+               #}
+               ; TODO: Make the input location point to the location of the *caller*
+               (oll:warn (format "Trying to install edition-engraver to non-existent context ~a" ctx))))
+         contexts)
+     }
+   #})

--- a/example-1.ly
+++ b/example-1.ly
@@ -11,21 +11,10 @@
 \editionMod test 1 2/4 sing.with.bach.along.Staff { \bar "||" \clef "alto" }
 \editionMod test 2 2/4 sing.with.bach.along.Staff \clef "G"
 
-\layout {
-  \context {
-    \Score
-    \consists \edition-engraver
-  }
-  \context {
-    \Staff
-    \consists \edition-engraver
-  }
-  \context {
-    \Voice
-    \consists \edition-engraver
-  }
-}
-
+% "Install" the edition-engraver in a number of contexts.
+% The order is not relevant,
+% Dynamics is not used in this example, Foo triggers an oll:warn
+\consistEE Score.Staff.Voice
 
 \layout {
   \context {


### PR DESCRIPTION
Provide a wrapper function to install the edition-engraver to an
arbitrary number of contexts with a single call (having to do all
that \layout mangling manually did significantly add complexity to
using the edition-engraver until now).

The function takes a symbol-list with context names and consists
the edition-engraver to all those contexts. Specifying an item that
doesn't map to an existing context triggers a (oll:) warning but doesn't
affect the other contexts.

TODOs:
- the warning about nonexistent context points to the edition-engraver,
  but it should point to the caller.
- It seems that consisting \edition-engraver to different context
  affects the voice count (addressing). This isn't related to the current
  code which just makes that visible. See issue #1