### PR TITLE
Reorder mod path

### DIFF
--- a/engine.scm
+++ b/engine.scm
@@ -418,7 +418,7 @@
             ;(ly:message "init ~A \"~A\"" context-edition-id (ly:context-id context))
             (for-each
              (lambda (context-edition-sid)
-               (ly:message "~A" context-edition-sid)
+               ;(ly:message "~A" context-edition-sid)
                (let ((mtree (tree-get-tree mod-tree context-edition-sid)))
                  (if (tree? mtree)
                      (tree-walk mtree '()
@@ -440,7 +440,7 @@
                                    ) '())
                (,@context-edition-id ,context-name ,(string->symbol (base26 context-edition-number)))
                ))
-            
+
             (tree-set! context-counter
               `(,@context-edition-id ,context-name)
               (cons context-edition-number context-id))

--- a/engine.scm
+++ b/engine.scm
@@ -368,31 +368,12 @@
 
     ; find mods for the current time-spec
     (define (find-mods)
-      (let ((current-mods '())
-            (moment (ly:context-current-moment context))
+      (let* (;(moment (ly:context-current-moment context))
             (measure (ly:context-property context 'currentBarNumber))
             (measurePos (ly:context-property context 'measurePosition))
-            )
-        (define (add-mods mods)
-          (if (and (list? mods)(> (length mods) 0))
-              (set! current-mods `(,@current-mods ,@mods))))
-        (for-each
-         (lambda (edition-target-id)
-           (let* ((mtree (tree-get-tree context-mods `(measure measurePos edition-target-id))))
-             (if (tree? context-mods)
-                 (begin
-                  (add-mods (tree-get context-mods (list context-name measure measurePos edition-target-id)))
-                  (add-mods (tree-get context-mods (list context-name
-                                                     (string->symbol (base26 context-edition-number))
-                                                     measure measurePos edition-target-id)))
-                  (if context-id
-                      (begin
-                       (add-mods (tree-get mtree (list context-id measure measurePos edition-target-id)))
-                       (add-mods (tree-get mtree (list context-name context-id measure measurePos edition-target-id)))
-                       ))
-                  ))
-             )) edition-targets)
-        current-mods))
+            (current-mods (tree-get context-mods (list measure measurePos))))
+        (if (list? current-mods) current-mods '())
+        ))
 
     `( ; TODO better use make-engraver macro?
        ; TODO slots: listeners, acknowledgers, end-acknowledgers, process-acknowledged

--- a/example-1.ly
+++ b/example-1.ly
@@ -8,8 +8,9 @@
 \editionMod test 4 0/4 sing.with.bach.along.Voice.A \revert NoteHead.color
 \editionModList test sing.with.bach.Score \break #'(4 8 12 16)
 
-\editionMod test 1 2/4 sing.with.bach.along.Staff { \bar "||" \clef "alto" }
+\editionMod test 1 2/4 sing.with.bach.along.Staff \clef "alto"
 \editionMod test 2 2/4 sing.with.bach.along.Staff \clef "G"
+\editionMod test 4 0/4 sing.with.bach.along.Staff \bar ".|:-||"
 
 % "Install" the edition-engraver in a number of contexts.
 % The order is not relevant,

--- a/example-1.ly
+++ b/example-1.ly
@@ -27,6 +27,6 @@
 \new Staff = "BACH" \with {
   \editionID along
 } <<
-  \repeat unfold 20 \relative c'' { bes4 a c b } \\
-  \repeat unfold 20 \relative c' { d4. e4 f8 g4 }
+  \new Voice \with { \voiceOne } { \repeat unfold 20 \relative c'' { bes4 a c b } }
+  \new Voice = "accom" \with { \voiceTwo } \repeat unfold 20 \relative c' { d4. e4 f8 g4 }
 >>


### PR DESCRIPTION
This path reorders the mod-path internally, so that it starts with the context-edition-id. In the initialize slot/phase, the engraver collects all mods from the global tree in a local one. Now mods for the current moment are collected from that tree.
It saves a lot of computing.
