### PR TITLE
Instant context creation

### DIFF
--- a/engine.scm
+++ b/engine.scm
@@ -366,7 +366,7 @@
     (define (log-slot slot) ; TODO: option verbose? oll logging function?
       (if (and (eq? (ly:context-property-where-defined context 'edition-engraver-log) context)
                (eq? #t (ly:context-property context 'edition-engraver-log #f)))
-          (ly:message "edition-engraver ~A ~A = \"~A\" : ~A" context-edition-id context-name (if (symbol? context-id) (symbol->string context-id) "") slot)))
+          (ly:message "edition-engraver ~A ~A = \"~A\" : ~A @ ~A" context-edition-id context-name (if (symbol? context-id) (symbol->string context-id) "") slot (ly:context-current-moment context))))
 
     ; find mods for the current time-spec
     (define (find-mods)
@@ -377,7 +377,8 @@
         (if (list? current-mods) current-mods '())
         ))
 
-    ; define start-translation-timestep
+    ; define start-translation-timestep to use it in initialize if needed
+    ; TODO: prevent from running twice in one time step
     (define (start-translation-timestep trans)
       (log-slot "start-translation-timestep")
       (set! current-engraver-slot 'start-translation-timestep)
@@ -428,7 +429,7 @@
                             edition-id) ; no inherit
                         (find-edition-id (ly:context-parent context)))) ; no edition-id
                   '())) ; if context
-            
+
             (set! context-edition-id (find-edition-id context))
             (set! context-edition-number
                   (let ((nr (tree-get context-counter `(,@context-edition-id ,context-name))))
@@ -441,7 +442,7 @@
               `(,@context-edition-id ,context-name
                  ,(string->symbol (base26 context-edition-number)))
               (if context-id (symbol->string context-id) ""))
-            
+
             ; copy all mods into this engravers mod-tree
             (set! context-mods
                   (tree-create (string->symbol

--- a/engine.scm
+++ b/engine.scm
@@ -378,7 +378,6 @@
         ))
 
     ; define start-translation-timestep to use it in initialize if needed
-    ; TODO: prevent from running twice in one time step
     (define (start-translation-timestep trans)
       (log-slot "start-translation-timestep")
       (if (or (not start-translation-timestep-moment)

--- a/example-1.ly
+++ b/example-1.ly
@@ -2,15 +2,15 @@
 \include "edition-engraver.ily"
 
 \addEdition test
-\editionMod test 1 2/4 sing.with.bach.along.Voice.A \override NoteHead.color = #green
-\editionMod test 1 3/4 sing.with.bach.along.Voice.A \override NoteHead.color = #blue
-\editionMod test 2 1/4 sing.with.bach.along.Voice.A \revert NoteHead.color
-\editionMod test 4 0/4 sing.with.bach.along.Voice.A \revert NoteHead.color
-\editionModList test sing.with.bach.Score \break #'(4 8 12 16)
+\editionMod test 2 2/4 sing.with.bach.along.Voice.B \override NoteHead.color = #green
+\editionMod test 2 3/4 sing.with.bach.along.Voice.B \override NoteHead.color = #blue
+\editionMod test 3 1/4 sing.with.bach.along.Voice.B \revert NoteHead.color
+\editionMod test 5 0/4 sing.with.bach.along.Voice.#(string->symbol "1") \revert NoteHead.color
+\editionModList test sing.with.bach.Score \break #'(5 9 13 17)
 
-\editionMod test 1 2/4 sing.with.bach.along.Staff \clef "alto"
-\editionMod test 2 2/4 sing.with.bach.along.Staff \clef "G"
-\editionMod test 4 0/4 sing.with.bach.along.Staff \bar ".|:-||"
+\editionMod test 2 2/4 sing.with.bach.along.Staff \clef "alto"
+\editionMod test 3 2/4 sing.with.bach.along.Staff \clef "G"
+\editionMod test 5 0/4 sing.with.bach.along.Staff \bar ".|:-||"
 
 % "Install" the edition-engraver in a number of contexts.
 % The order is not relevant,

--- a/example-1.ly
+++ b/example-1.ly
@@ -8,6 +8,7 @@
 \editionMod test 2 2/4 sing.with.bach.along.Voice.B \override NoteHead.color = #green
 \editionMod test 2 3/4 sing.with.bach.along.Voice.B \override NoteHead.color = #blue
 \editionMod test 3 1/4 sing.with.bach.along.Voice.B \revert NoteHead.color
+% how to enter this?
 \editionMod test 5 0/4 sing.with.bach.along.Voice.#(string->symbol "1") \revert NoteHead.color
 
 \editionMod test 13 3/8 sing.with.bach.along.Voice.C \once \override NoteHead.color = #red

--- a/example-1.ly
+++ b/example-1.ly
@@ -2,10 +2,17 @@
 \include "edition-engraver.ily"
 
 \addEdition test
+
+\editionMod test 2 0/4 sing.with.bach.along.Voice.B \once \override NoteHead.color = #red
+
 \editionMod test 2 2/4 sing.with.bach.along.Voice.B \override NoteHead.color = #green
 \editionMod test 2 3/4 sing.with.bach.along.Voice.B \override NoteHead.color = #blue
 \editionMod test 3 1/4 sing.with.bach.along.Voice.B \revert NoteHead.color
 \editionMod test 5 0/4 sing.with.bach.along.Voice.#(string->symbol "1") \revert NoteHead.color
+
+\editionMod test 13 3/8 sing.with.bach.along.Voice.C \once \override NoteHead.color = #red
+
+
 \editionModList test sing.with.bach.Score \break #'(5 9 13 17)
 
 \editionMod test 2 2/4 sing.with.bach.along.Staff \clef "alto"
@@ -39,6 +46,7 @@
   >>
   <<
     \repeat unfold 10 \relative c'' { bes4 a c b } \\
-    \repeat unfold 10 \relative c' { d4. e4 f8 g4 }
+    \repeat unfold 10 \relative c' { d4. e4 f8 g4 } \\
+    \repeat unfold 10 \relative c' { f2 a }
   >>
 }

--- a/example-1.ly
+++ b/example-1.ly
@@ -27,7 +27,13 @@
 
 \new Staff = "BACH" \with {
   \editionID along
-} <<
-  \new Voice \with { \voiceOne } { \repeat unfold 20 \relative c'' { bes4 a c b } }
-  \new Voice = "accom" \with { \voiceTwo } \repeat unfold 20 \relative c' { d4. e4 f8 g4 }
->>
+} {
+  <<
+    \repeat unfold 10 \relative c'' { bes4 a c b } \\
+    \repeat unfold 10 \relative c' { d4. e4 f8 g4 }
+  >>
+  <<
+    \repeat unfold 10 \relative c'' { bes4 a c b } \\
+    \repeat unfold 10 \relative c' { d4. e4 f8 g4 }
+  >>
+}

--- a/example-1.ly
+++ b/example-1.ly
@@ -23,11 +23,16 @@
     \editionID ##f sing.with.bach
     %edition-engraver-log = ##t
   }
+  \context {
+    \Voice
+    edition-engraver-log = ##t
+  }
 }
 
 \new Staff = "BACH" \with {
   \editionID along
 } {
+  R1
   <<
     \repeat unfold 10 \relative c'' { bes4 a c b } \\
     \repeat unfold 10 \relative c' { d4. e4 f8 g4 }


### PR DESCRIPTION
This is a fix, to call translation-timestep in initialize for instantly created contexts, like Voices in <<\\>>-contructs.