### PR TITLE
WIP Initial implementation of ID mods

### DIFF
--- a/edition-engraver.ily
+++ b/edition-engraver.ily
@@ -1,40 +1,8 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                                                                             %
-% This file is part of openLilyLib,                                           %
-%                      ===========                                            %
-% the community library project for GNU LilyPond                              %
-% (https://github.com/openlilylib)                                            %
-%              -----------                                                    %
-%                                                                             %
-% Library: edition-engraver                                                   %
-%          ================                                                   %
-%                                                                             %
-% openLilyLib is free software: you can redistribute it and/or modify         %
-% it under the terms of the GNU General Public License as published by        %
-% the Free Software Foundation, either version 3 of the License, or           %
-% (at your option) any later version.                                         %
-%                                                                             %
-% openLilyLib is distributed in the hope that it will be useful,              %
-% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
-% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
-% GNU General Public License for more details.                                %
-%                                                                             %
-% You should have received a copy of the GNU General Public License           %
-% along with openLilyLib. If not, see <http://www.gnu.org/licenses/>.         %
-%                                                                             %
-% openLilyLib is maintained by Urs Liska, ul@openlilylib.org                  %
-% edition-engraver is maintained by Jan-Peter Voigt, jp.voigt@gmx.de          %
-% and others.                                                                 %
-%       Copyright Jan-Peter Voigt, Urs Liska, 2016                            %
-%                                                                             %
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+#(ly:message "
 
-\version "2.19.36"
-\include "oll-core/package.ily"
+You have included \"edition-engraver/edition-engraver.ily\".
+This is deprecated, please include \"edition-engraver/package.ily\" instead.
 
-% activate edition-engraver module
-#(use-modules (edition-engraver engine))
-% Function to consist the EE in multiple contexts
-\include "oll-core/util/consist-to-contexts.ily"
-
-\include "id-mods.ily"
+")
+#(ly:set-option 'relative-includes #t)
+\include "package.ily"

--- a/id-mods.ily
+++ b/id-mods.ily
@@ -1,0 +1,136 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                             %
+% This file is part of openLilyLib,                                           %
+%                      ===========                                            %
+% the community library project for GNU LilyPond                              %
+% (https://github.com/openlilylib)                                            %
+%              -----------                                                    %
+%                                                                             %
+% Library: edition-engraver                                                   %
+%          ================                                                   %
+%                                                                             %
+% openLilyLib is free software: you can redistribute it and/or modify         %
+% it under the terms of the GNU General Public License as published by        %
+% the Free Software Foundation, either version 3 of the License, or           %
+% (at your option) any later version.                                         %
+%                                                                             %
+% openLilyLib is distributed in the hope that it will be useful,              %
+% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+% GNU General Public License for more details.                                %
+%                                                                             %
+% You should have received a copy of the GNU General Public License           %
+% along with openLilyLib. If not, see <http://www.gnu.org/licenses/>.         %
+%                                                                             %
+% openLilyLib is maintained by Urs Liska, ul@openlilylib.org                  %
+% edition-engraver is maintained by Jan-Peter Voigt, jp.voigt@gmx.de          %
+% and others.                                                                 %
+%       Copyright Jan-Peter Voigt, Urs Liska, 2016                            %
+%                                                                             %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+\registerOption ee.id-mods #'()
+
+#(set-object-property! 'eid 'backend-type? symbol?)
+
+#(define (key-value-pair? obj)
+   (and
+    (pair? obj)
+    (symbol? (car obj))))
+
+#(define (ee-prop-list? obj)
+   (and (list? obj)
+        (every key-value-pair? obj)))
+
+% Apply a mod to an individual ID.
+% Arguments:
+% - id: a symbol
+% - prop: property name
+% - val: the new value
+% prop and val are checked to be present and matching
+idMod =
+#(define-void-function (id prop val) (symbol? symbol? scheme?)
+   (setChildOption #t `(ee id-mods ,id) prop val))
+
+% Apply multiple mods to an individual ID.
+% Arguments:
+% - id: a symbol
+% - items: a list of key-value pairs
+idMods =
+#(define-void-function (id items) (symbol? ee-prop-list?)
+   (for-each
+    (lambda (item)
+      (idMod id (car item) (cdr item)))
+    items))
+
+% Apply a mod to a list of IDs.
+% Arguments:
+% - prop: property name
+% - val: value to be applied to all IDs
+% - ids: list of IDs (symbol-list?)
+% prop and val are checked to be present and matching
+idModList =
+#(define-void-function (prop val ids) (symbol? scheme? symbol-list?)
+   (for-each
+    (lambda (id)
+      (idMod id prop val))
+    ids))
+
+% Apply (variable) values to a list of IDs
+% Arguments:
+% - prop: property name
+% - default: default value
+% - items: list of items, where each item is one of
+%   - id (symbol?)
+%   - list of id and value
+% prop, default and each val are checked
+% if items is a two-element list the first is the ID and
+% the second the value. If it is a single symbol this is
+% the ID, and the default value is applied.
+idVarModList =
+#(define-scheme-function (prop default items) (symbol? scheme? list?)
+   (display items)
+   (for-each
+    (lambda (item ind)
+      (let ((id (if (list? item)
+                    (first item)
+                    item))
+            (val (if (list? item)
+                     (cdr item)
+                     default)))
+        (idMod id prop val)))
+    items (iota (length items))))
+
+#(define (id-mods grob)
+   "Check if ID mods are registered for this grob and
+    apply them as property overrides.
+    Special treatment is done to the force-right-nc mod."
+   (let*
+    ((_id-mods
+      (or
+       (assq-ref (getOption '(ee id-mods)) (ly:grob-property grob 'eid))
+       '())))
+    (for-each
+     (lambda (mod)
+       (ly:grob-set-property! grob (car mod) (cdr mod)))
+     _id-mods)))
+
+% Function to "install" the ID mod functionality to multiple grob types
+% Expects a symbol-list? with grob names.
+activateIdMods =
+#(define-scheme-function (grobs)(symbol-list?)
+   #{
+     \layout {
+       \context {
+         \Score
+         #@(map
+         (lambda (grob)
+         #{
+           \override #`(,grob before-line-breaking) = #id-mods
+           #})
+         grobs)
+       }
+     }
+   #})
+

--- a/package.ily
+++ b/package.ily
@@ -29,60 +29,12 @@
 %                                                                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\version "2.19.37"
-\include "edition-engraver/edition-engraver.ily"
+\version "2.19.36"
+\include "oll-core/package.ily"
 
-\activateIdMods Tie.NoteHead.Beam
+% activate edition-engraver module
+#(use-modules (edition-engraver engine))
+% Function to consist the EE in multiple contexts
+\include "oll-core/util/consist-to-contexts.ily"
 
-% Apply a single property override to a single grob
-\idMod #'b color #red
-
-% Apply multiple property overrides to a single grob
-\idMods A
-#`((color . ,blue)
-   (extra-offset . (-1.5 . -0.5)))
-
-\relative c' {
-  <c -\tweak Tie.eid #'a ~
-  \tweak eid #'A
-  e
-  -\tweak Tie.eid #'b ~
-  g -\tweak Tie.eid #'c ~
-  c -\tweak Tie.eid #'d ~
-  >1
-  <c e g c>
-}
-
-% Apply the same property override to multiple grobs
-\idModList positions #'(4 . 4) #'(Ba Bb Bc Bd)
-\relative {
-  \stemUp
-  \once \override Beam.eid = #'Ba
-  c'8 d e f
-  \once \override Beam.eid = #'Bb
-  g e d b'
-  \once \override Beam.eid = #'Bc
-  c e a, c
-  \once \override Beam.eid = #'Bd
-  fis, a dis, fis
-}
-
-% Apply different values to the same property of multiple grobs
-% Not specifying the value for a grob uses the default
-\idVarModList color #red
-#`((Be . ,blue)
-   (Bf . ,magenta)
-   Bg
-   (Bh . ,green))
-
-\relative {
-  \stemUp
-  \once \override Beam.eid = #'Be
-  c'8 d e f
-  \once \override Beam.eid = #'Bf
-  g e d b'
-  \once \override Beam.eid = #'Bg
-  c e a, c
-  \once \override Beam.eid = #'Bh
-  fis, a dis, fis
-}
+\include "id-mods.ily"

--- a/usage-examples/id-mods.ly
+++ b/usage-examples/id-mods.ly
@@ -29,12 +29,60 @@
 %                                                                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\version "2.19.36"
-\include "oll-core/package.ily"
+\version "2.19.37"
+\include "edition-engraver/package.ily"
 
-% activate edition-engraver module
-#(use-modules (edition-engraver engine))
-% Function to consist the EE in multiple contexts
-\include "oll-core/util/consist-to-contexts.ily"
+\activateIdMods Tie.NoteHead.Beam
 
-\include "id-mods.ily"
+% Apply a single property override to a single grob
+\idMod #'b color #red
+
+% Apply multiple property overrides to a single grob
+\idMods A
+#`((color . ,blue)
+   (extra-offset . (-1.5 . -0.5)))
+
+\relative c' {
+  <c -\tweak Tie.eid #'a ~
+  \tweak eid #'A
+  e
+  -\tweak Tie.eid #'b ~
+  g -\tweak Tie.eid #'c ~
+  c -\tweak Tie.eid #'d ~
+  >1
+  <c e g c>
+}
+
+% Apply the same property override to multiple grobs
+\idModList positions #'(4 . 4) #'(Ba Bb Bc Bd)
+\relative {
+  \stemUp
+  \once \override Beam.eid = #'Ba
+  c'8 d e f
+  \once \override Beam.eid = #'Bb
+  g e d b'
+  \once \override Beam.eid = #'Bc
+  c e a, c
+  \once \override Beam.eid = #'Bd
+  fis, a dis, fis
+}
+
+% Apply different values to the same property of multiple grobs
+% Not specifying the value for a grob uses the default
+\idVarModList color #red
+#`((Be . ,blue)
+   (Bf . ,magenta)
+   Bg
+   (Bh . ,green))
+
+\relative {
+  \stemUp
+  \once \override Beam.eid = #'Be
+  c'8 d e f
+  \once \override Beam.eid = #'Bf
+  g e d b'
+  \once \override Beam.eid = #'Bg
+  c e a, c
+  \once \override Beam.eid = #'Bh
+  fis, a dis, fis
+}


### PR DESCRIPTION
ID mods are property overrides that are addressed to individual
grobs by their ID.

They are able to apply everything that can be achieved through overriding grob properties, i.e. everything that can be done with `\once \override` or `\tweak`.

One potential issue I see is that using the ID mods "uses up" the `before-line-breaking` callback of the grobs that are activated.

Another thing to be discussed is the new grob property `'eid`I defined. Of course it would be more natural to use the existing `'id` property. But using IDs to address elements and to store mods requires the ID property to be of type `symbol?` because there will be a potentially huge alist with mods, and symbols are significantly more efficient as lookup keys.

Finally I'm not completely sure if the naming of the mod commands is ideal:

* `\idMod`
* `\idMods`
* `\idModList`
* `\idVarModList`

is the current state. I deliberately leave that uncommented here so people can look at them without being told beforehand what they mean. Their meaning and use is commented in the source files.

---

The fundamental question is if these functions are a natural fit as complement to the existing edition-engraver mods.

* Is it a good idea to add this option to the edition-engraver in this way?
* Should the edition-engraver functions themselves be updated instead so they can also work with IDs?
* Or should the ID mods be separated out in their own package?
* Is the naming sufficiently consistent?